### PR TITLE
Add a "--platform-tag" flag

### DIFF
--- a/change_wheel_version.py
+++ b/change_wheel_version.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, no_type_check
 
 import installer.utils
 import packaging.version
+from packaging.tags import parse_tag
 
 
 def version_replace(v: packaging.version.Version, **kwargs: Any) -> packaging.version.Version:
@@ -46,22 +47,45 @@ def wheel_unpack(wheel: Path, dest_dir: Path, name_ver: str) -> None:
         wf.extractall(dest_dir / name_ver)
 
 
+def change_platform_tag(wheel_path: Path, tag: str, parser: email.parser.BytesParser) -> str:
+    """Changes the WHEEL file to specify `tag`. Returns a canonicalized copy of that tag."""
+    platform_tags = list(parse_tag(tag))
+    if len(platform_tags) != 1:
+        raise ValueError(f"Parsed '{tag}' as {len(platform_tags)}; there must be exactly one.")
+    platform_tag = platform_tags[0]
+    is_pure = platform_tag.abi == "none"
+    if is_pure != (platform_tag.platform == "any"):
+        raise ValueError(f"ABI and platform are inconsistent in '{platform_tag}'.")
+    if is_pure != platform_tag.interpreter.startswith("py"):
+        raise ValueError(f"Interpreter and platform are inconsistent in '{platform_tag}'.")
+    with open(wheel_path, "rb") as f:
+        msg = parser.parse(f)
+    msg.replace_header("Tag", str(platform_tag))
+    msg.replace_header("Root-Is-Purelib", str(is_pure).lower())
+    with open(wheel_path, "wb") as f:
+        f.write(msg.as_bytes())
+    return str(platform_tag)
+
+
 def change_wheel_version(
     wheel: Path,
     version: Optional[str],
     local_version: Optional[str],
     allow_same_version: bool = False,
+    platform_tag: Optional[str] = None,
 ) -> Path:
     old_parts = installer.utils.parse_wheel_filename(wheel.name)
     old_version = packaging.version.Version(old_parts.version)
     distribution = old_parts.distribution
 
     if version is None:
-        # just replace the local version
-        assert local_version is not None
-        new_version = version_replace(
-            old_version, local=packaging.version._parse_local_version(local_version)
-        )
+        if local_version is not None:
+            # just replace the local version
+            new_version = version_replace(
+                old_version, local=packaging.version._parse_local_version(local_version)
+            )
+        else:
+            new_version = old_version
     else:
         # replace the base version and (possibly) the local version
         new_version = packaging.version.Version(version)
@@ -101,7 +125,8 @@ def change_wheel_version(
                 dest_dir / new_slug / f"{old_slug}.data", dest_dir / new_slug / f"{new_slug}.data"
             )
 
-        metadata = dest_dir / new_slug / f"{new_slug}.dist-info" / "METADATA"
+        metadata_path = dest_dir / new_slug / f"{new_slug}.dist-info" / "METADATA"
+        wheel_path = dest_dir / new_slug / f"{new_slug}.dist-info" / "WHEEL"
 
         # This is actually a non-conformant email policy as per
         # https://packaging.python.org/en/latest/specifications/core-metadata/
@@ -109,17 +134,24 @@ def change_wheel_version(
         # https://github.com/pypa/setuptools/issues/3808
         max_line_length = 200
         policy = email.policy.compat32.clone(max_line_length=200)
+        parser = email.parser.BytesParser(policy=policy)
         version_str = str(new_version)
         if len(version_str) >= max_line_length:
             raise ValueError(f"Version {version_str} is too long")
 
-        with open(metadata, "rb") as f:
-            parser = email.parser.BytesParser(policy=policy)
+        with open(metadata_path, "rb") as f:
             msg = parser.parse(f)
-
         msg.replace_header("Version", version_str)
-        with open(metadata, "wb") as f:
+        with open(metadata_path, "wb") as f:
             f.write(msg.as_bytes())
+
+        if platform_tag:
+            # We don't need to sort, because we assume len(parse_tag(platform_tag)) == 1
+            new_tag = change_platform_tag(wheel_path, platform_tag, parser)
+        else:
+            # Generate the tags that will be associated with the wheel after it is repacked.
+            # `wheel pack` sorts the tags, so we need to do the same if we're not changing it.
+            new_tag = "-".join(".".join(sorted(t.split("."))) for t in old_parts.tag.split("-"))
 
         # wheel pack rewrites the RECORD file
         subprocess.check_output(
@@ -134,8 +166,6 @@ def change_wheel_version(
             ]
         )
 
-    # wheel pack sorts the tag, so we need to do the same
-    new_tag = "-".join(".".join(sorted(t.split("."))) for t in old_parts.tag.split("-"))
     new_parts = old_parts._replace(version=str(new_version), tag=new_tag)
     new_wheel_name = "-".join(p for p in new_parts if p) + ".whl"
     new_wheel = wheel.with_name(new_wheel_name)
@@ -155,6 +185,11 @@ def main() -> None:
     parser.add_argument("--version")
     parser.add_argument("--delete-old-wheel", action="store_true")
     parser.add_argument("--allow-same-version", action="store_true")
+    parser.add_argument(
+        "--platform-tag",
+        help="Force the platform tag to this value. For example, 'py3-none-any'. See "
+        "https://packaging.python.org/en/latest/specifications/platform-compatibility-tags.",
+    )
     args = parser.parse_args()
 
     new_wheel = change_wheel_version(
@@ -162,6 +197,7 @@ def main() -> None:
         version=args.version,
         local_version=args.local_version,
         allow_same_version=args.allow_same_version,
+        platform_tag=args.platform_tag,
     )
     print(new_wheel)
     if args.delete_old_wheel:


### PR DESCRIPTION
This lets you change the declared platform of a wheel, which can be useful if a tool has chosen the wrong one.